### PR TITLE
#12 Refactored _getCommand to only match complete commands

### DIFF
--- a/util/command.js
+++ b/util/command.js
@@ -45,18 +45,15 @@ var _getCommand = function(userCommand) {
 	if (!userCommand) {
 		return util.config.get('ERROR_COMMAND');
 	}
-  userCommand = userCommand.replace(/([.?*+^$[\]\\(){}|-])/g, "\\$1");
-	var pattern = new RegExp('\\[(([^\\[]*[,])?' + userCommand + '[^\\]]*)\\]', 'i'),
-		matches = cmdPattern.match(pattern) && cmdPattern.match(pattern)[0];
+  	userCommand = userCommand.replace(/([.?*+^$[\]\\(){}|-])/g, "\\$1");
+	var pattern = new RegExp('\\[(([^\\[]*[,])?' + userCommand + ')[\\]|,]', 'i'),
+		matches = cmdPattern.match(pattern);
 
 	if (!matches) {
 		return util.config.get('ERROR_COMMAND');
 	}
 
-	var	strippedMatch = ( matches.match(/\[(.*)\]/) && matches.match(/\[(.*)\]/)[1] ) || '',
-		aliases = strippedMatch.split(',') || [];
-	return aliases.length ? aliases[0] : util.config.get('ERROR_COMMAND');
-
+	return matches[1].split(',')[0];
 };
 
 var init = function () {


### PR DESCRIPTION
This modification should sort out the issue mentioned in issue #12. The regex now only matches the complete command or alias. Before it was matching any pattern up to the full command name.

E.G "h" -> "help"
"he" -> "help"
"ha" -> "halp"
"g" -> "gem"
etc.